### PR TITLE
fix: 동시성 제어를 위해 트랜잭션 제거

### DIFF
--- a/src/main/java/io/nugulticket/auction/service/AuctionService.java
+++ b/src/main/java/io/nugulticket/auction/service/AuctionService.java
@@ -21,7 +21,6 @@ import java.time.LocalDate;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-@Transactional(readOnly = true)
 public class AuctionService {
     private final AuctionRepository auctionRepository;
     private final TicketService ticketService;
@@ -46,7 +45,6 @@ public class AuctionService {
      * @param reqDto 가격 정보가 담긴 Request 객체
      * @return 해당 경매의 현재 정보가 담긴 Response 객체
      */
-    @Transactional
     @RedisDistributedLock(key = "updateAuction")
     public BidActionResponse updateAction(long auctionId, BidActionRequest reqDto) {
         Auction auction = auctionRepository.findByIdWithPessimisticLock(auctionId).orElseThrow(

--- a/src/main/java/io/nugulticket/config/RedisConfig.java
+++ b/src/main/java/io/nugulticket/config/RedisConfig.java
@@ -1,6 +1,11 @@
 package io.nugulticket.config;
 
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,4 +43,17 @@ public class RedisConfig {
 
         return template;
     }
+//
+//    @Bean
+//    public RedissonClient redissonClient() {
+//        Config config = new Config();
+//        config.useSingleServer()
+//                .setAddress("redis://" + host + ":" + port) // 호스트와 포트 동적으로 설정
+//                .setConnectionPoolSize(64)
+//                .setConnectionMinimumIdleSize(10)
+//                .setTimeout(3000)
+//                .setRetryAttempts(3)
+//                .setRetryInterval(1500);
+//        return Redisson.create(config);
+//    }
 }

--- a/src/main/java/io/nugulticket/lock/RedisDistributedLockAspect.java
+++ b/src/main/java/io/nugulticket/lock/RedisDistributedLockAspect.java
@@ -34,7 +34,9 @@ public class RedisDistributedLockAspect {
                     return joinPoint.proceed(); // 메서드 실행
                 } finally {
                     log.info("fair lock finally");
-                    lock.unlock(); // 락 해제
+//                    if (lock.isHeldByCurrentThread()) { // 현재 스레드가 락을 보유한 경우에만 해제
+                        lock.unlock();
+//                    }
                 }
             } else {
                 log.info("fair lock fail");

--- a/src/main/java/io/nugulticket/ticket/service/TicketService.java
+++ b/src/main/java/io/nugulticket/ticket/service/TicketService.java
@@ -81,7 +81,6 @@ public class TicketService {
      * @param authUser 현재 로그인 중인 유저 정보
      * @return 결제에 사용될 정보가 담긴 Response 객체
      */
-    @Transactional
     @RedisDistributedLock(key = "createTicket")
     public TicketNeedPaymentResponse createTicket(CreateTicketRequest reqDto, AuthUser authUser) {
         Seat seat = seatService.findSeatById(reqDto.getSeatId()); // 락 필요

--- a/src/main/java/io/nugulticket/ticket/service/TicketTransferService.java
+++ b/src/main/java/io/nugulticket/ticket/service/TicketTransferService.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class TicketTransferService {
@@ -37,7 +36,6 @@ public class TicketTransferService {
      * @param ticketId 양도 신청을 넣을 TicketId
      * @return 양도 결과가 담긴 Dto객체
      */
-    @Transactional
     @RedisDistributedLock(key = "applyTransferBeforePayment")
     public TicketNeedPaymentResponse applyTransferBeforePayment(AuthUser users, Long ticketId) {
         User user = userService.getUser(users.getId());
@@ -129,6 +127,7 @@ public class TicketTransferService {
      * 내가 양도하거나, 양도 받은 Ticket 이력을 조회하는 메서드
      * @return 내가 양도하거나, 양도 받은 Ticket 이력이 담긴 Dto객체
      */
+    @Transactional(readOnly = true)
     public MyTransferTicketsResponse getMyTransferTicket(AuthUser user) {
         List<Ticket> tickets = ticketService.getAllTicketJoinFetchEventSeat(TicketStatus.WAITTRANSFER, user.getId());
 


### PR DESCRIPTION
Redis 락은 트랜잭션과 무관하게 즉시 해제된다. 즉, 락이 해제된 후에도 트랜잭션이 커밋되지 않았다면, 다른 요청이 락을 획득하고 동일한 데이터에 접근 가능하다. 트랜잭션 보장은 일단 추후에 다시 확인